### PR TITLE
Update start offset after matching string

### DIFF
--- a/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
+++ b/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
@@ -134,6 +134,7 @@ class TCFConverter {
             annotation.end = end
             tokens.add(annotation)
             offsets[token.ID] = new Offsets(start, end)
+            start = end;
         }
     }
 


### PR DESCRIPTION
Start offset was not being updated after matching a string so String.indexOf(String,int) may match the same string multiple times.