### PR TITLE
fixed parse trees converted from TCF missing spans

### DIFF
--- a/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
+++ b/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
@@ -31,7 +31,6 @@ import org.lappsgrid.discriminator.Discriminators.Uri
 import org.lappsgrid.serialization.Data
 import org.lappsgrid.serialization.lif.Annotation
 import org.lappsgrid.serialization.lif.Container
-import org.lappsgrid.serialization.lif.Contains
 import org.lappsgrid.serialization.lif.View
 import org.lappsgrid.vocabulary.Features
 
@@ -265,6 +264,9 @@ class TCFConverter {
         ConstituentParsingLayer parseLayer = corpus.getConstituentParsingLayer()
         if (!parseLayer) return
 
+        // needed to get char offsets of sentences
+        List<Annotation> sentences = container.findViewsThatContain(Uri.SENTENCE)[-1].getAnnotations();
+
         View constituentView = (View) container.newView('constituent-view')
         constituentView.addContains(Uri.PHRASE_STRUCTURE, producer, "phrase_structure:fromTCF")
 
@@ -280,6 +282,7 @@ class TCFConverter {
         // for each parse (sentence), create a new annotation of PS
         for (int sentId = 0; sentId < parseLayer.size(); sentId++) {
             ConstituentParse parse = parseLayer.getParse(sentId);
+            Annotation sentence = sentences[sentId];
             Constituent root = parse.getRoot()
             int constId = 0
             Queue<Filiation> queue = new LinkedList<>();
@@ -325,10 +328,11 @@ class TCFConverter {
             }
             // FIXME See above
 //            constituentIds.addAll(parseLayer.getTokens(root).collect({"token-view:${it.getID()}"}))
-            constituentIds.addAll(parseLayer.getTokens(root).collect{ it.getID() })
+//            constituentIds.addAll(parseLayer.getTokens(root).collect{ it.getID() })
 
             // and then add a "phrase structure" annotation for the current sentence
-            Annotation phraseStructure = constituentView.newAnnotation("ps_" + (sentId), Uri.PHRASE_STRUCTURE, )
+            Annotation phraseStructure = constituentView.newAnnotation(
+                    "ps_" + (sentId), Uri.PHRASE_STRUCTURE, sentence.getStart(), sentence.getEnd());
             phraseStructure.addFeature(Features.PhraseStructure.CONSTITUENTS, constituentIds)
             phraseStructure.setLabel()
         }
@@ -337,6 +341,9 @@ class TCFConverter {
     void processDependencies(TextCorpus corpus) {
         DependencyParsingLayer parseLayer = corpus.getDependencyParsingLayer()
         if (!parseLayer) return
+
+        // needed to get char offsets of sentences
+        List<Annotation> sentences = container.findViewsThatContain(Uri.SENTENCE)[-1].getAnnotations();
 
         View dependencyView = (View) container.newView('dependency-view')
         dependencyView.addContains(Uri.DEPENDENCY_STRUCTURE, producer, "dependency_structure:fromTCF")
@@ -353,6 +360,7 @@ class TCFConverter {
         // for each parse (sentence), create a new annotation of PS
         for (int sentId = 0; sentId < parseLayer.size(); sentId++) {
             DependencyParse parse = parseLayer.getParse(sentId)
+            Annotation sentence = sentences[sentId];
             int depId = 0
             List<String> dependencyIds = new LinkedList<>()
             for (Dependency dep : parse.getDependencies()) {
@@ -369,7 +377,7 @@ class TCFConverter {
                 }
                 dependencyIds.add(dependencyId)
             }
-            dependencyView.newAnnotation("depstr_${sentId}", Uri.DEPENDENCY_STRUCTURE).
+            dependencyView.newAnnotation("depstr_${sentId}", Uri.DEPENDENCY_STRUCTURE, sentence.getStart(), sentence.getEnd()).
                     addFeature(Features.DependencyStructure.DEPENDENCIES, dependencyIds)
         }
     }

--- a/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
+++ b/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
@@ -105,8 +105,8 @@ class TCFConverterTests {
         Map<String, String> labels = new HashMap<>()
         for (Annotation annotation : annotations) {
             if (annotation.getAtType() == Uri.PHRASE_STRUCTURE) {
-                // 12 non-terminals and 6 terminals
-                assertEquals(18, parseListString(annotation.getFeature(Features.PhraseStructure.CONSTITUENTS)).length)
+                // 12 constituents and 6 tokens
+                assertEquals(12, parseListString(annotation.getFeature(Features.PhraseStructure.CONSTITUENTS)).length)
             } else {
                 parseListString(annotation.getFeature(Features.Constituent.CHILDREN)).each { String child ->
                     filiations.put(child.replaceAll("^.+:", ""), annotation.getId())


### PR DESCRIPTION
* addressing lapps-clarin/converter-issues#9 and
lapps-clarin/converter-issues#10