### PR TITLE
Allow the container to pick view ids

### DIFF
--- a/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
+++ b/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
@@ -315,8 +315,7 @@ class TCFConverter {
                 constituent.addFeature(Features.Constituent.PARENT, curNode.parent)
                 List<String> childrenIDs
                 if (curNode.node.isTerminal()) {
-                    // FIXME Why a class not found for the closure?
-                    childrenIDs = parseLayer.getTokens(curNode.getNode()).collect({"${tokenViewId}:${it.getID()}"})
+                    childrenIDs = parseLayer.getTokens(curNode.getNode()).collect {"${tokenViewId}:${it.getID()}".toString()}
                     // FIXME See hack-around above.
 //                    childrenIDs = parseLayer.getTokens(curNode.getNode()).collect { it.getID() }
                 } else {
@@ -331,7 +330,7 @@ class TCFConverter {
             }
             // FIXME See above
             // Fixed
-            constituentIds.addAll(parseLayer.getTokens(root).collect({"${tokenViewId}:${it.getID()}"}))
+//            constituentIds.addAll(parseLayer.getTokens(root).collect({"${tokenViewId}:${it.getID()}".toString()}))
 //            constituentIds.addAll(parseLayer.getTokens(root).collect{ it.getID() })
 
             // and then add a "phrase structure" annotation for the current sentence

--- a/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
+++ b/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
@@ -31,7 +31,6 @@ import org.lappsgrid.discriminator.Discriminators.Uri
 import org.lappsgrid.serialization.Data
 import org.lappsgrid.serialization.lif.Annotation
 import org.lappsgrid.serialization.lif.Container
-import org.lappsgrid.serialization.lif.Contains
 import org.lappsgrid.serialization.lif.View
 import org.lappsgrid.vocabulary.Features
 
@@ -265,6 +264,9 @@ class TCFConverter {
         ConstituentParsingLayer parseLayer = corpus.getConstituentParsingLayer()
         if (!parseLayer) return
 
+        // needed to get char offsets of sentences
+        List<Annotation> sentences = container.findViewsThatContain(Uri.SENTENCE)[-1].getAnnotations();
+
         View constituentView = (View) container.newView('constituent-view')
         constituentView.addContains(Uri.PHRASE_STRUCTURE, producer, "phrase_structure:fromTCF")
 
@@ -280,6 +282,7 @@ class TCFConverter {
         // for each parse (sentence), create a new annotation of PS
         for (int sentId = 0; sentId < parseLayer.size(); sentId++) {
             ConstituentParse parse = parseLayer.getParse(sentId);
+            Annotation sentence = sentences[sentId];
             Constituent root = parse.getRoot()
             int constId = 0
             Queue<Filiation> queue = new LinkedList<>();
@@ -325,10 +328,11 @@ class TCFConverter {
             }
             // FIXME See above
 //            constituentIds.addAll(parseLayer.getTokens(root).collect({"token-view:${it.getID()}"}))
-            constituentIds.addAll(parseLayer.getTokens(root).collect{ it.getID() })
+//            constituentIds.addAll(parseLayer.getTokens(root).collect{ it.getID() })
 
             // and then add a "phrase structure" annotation for the current sentence
-            Annotation phraseStructure = constituentView.newAnnotation("ps_" + (sentId), Uri.PHRASE_STRUCTURE, )
+            Annotation phraseStructure = constituentView.newAnnotation(
+                    "ps_" + (sentId), Uri.PHRASE_STRUCTURE, sentence.getStart(), sentence.getEnd());
             phraseStructure.addFeature(Features.PhraseStructure.CONSTITUENTS, constituentIds)
             phraseStructure.setLabel()
         }
@@ -337,6 +341,9 @@ class TCFConverter {
     void processDependencies(TextCorpus corpus) {
         DependencyParsingLayer parseLayer = corpus.getDependencyParsingLayer()
         if (!parseLayer) return
+
+        // needed to get char offsets of sentences
+        List<Annotation> sentences = container.findViewsThatContain(Uri.SENTENCE)[-1].getAnnotations();
 
         View dependencyView = (View) container.newView('dependency-view')
         dependencyView.addContains(Uri.DEPENDENCY_STRUCTURE, producer, "dependency_structure:fromTCF")
@@ -353,6 +360,7 @@ class TCFConverter {
         // for each parse (sentence), create a new annotation of PS
         for (int sentId = 0; sentId < parseLayer.size(); sentId++) {
             DependencyParse parse = parseLayer.getParse(sentId)
+            Annotation sentence = sentences[sentId];
             int depId = 0
             List<String> dependencyIds = new LinkedList<>()
             for (Dependency dep : parse.getDependencies()) {
@@ -369,7 +377,7 @@ class TCFConverter {
                 }
                 dependencyIds.add(dependencyId)
             }
-            dependencyView.newAnnotation("depstr_${sentId}", Uri.DEPENDENCY_STRUCTURE).
+            dependencyView.newAnnotation("depstr_${sentId}", Uri.DEPENDENCY_STRUCTURE, sentence.getStart(), sentence.getEnd()).
                     addFeature(Features.DependencyStructure.DEPENDENCIES, dependencyIds)
         }
     }

--- a/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
+++ b/src/main/groovy/org/lappsgrid/converter/tcf/TCFConverter.groovy
@@ -48,6 +48,8 @@ class TCFConverter {
     // FIXME This will not be needed once Weblicht supports view ID references.
     List<Annotation> tokens
 
+    String tokenViewId
+
     Container container
 
     String producer = this.class.getName()
@@ -114,7 +116,9 @@ class TCFConverter {
             return
         }
 
-        View view = container.newView('token-view')
+        View view = container.newView()
+        tokenViewId = view.id
+
         view.addContains(Uri.TOKEN, producer, "token:fromTCF")
         String text = container.text
         int n = layer.size()
@@ -241,7 +245,7 @@ class TCFConverter {
     void processNE(TextCorpus corpus) {
         NamedEntitiesLayer layer = corpus.getNamedEntitiesLayer()
         if (!layer) return
-        View view = container.newView("ne-view")
+        View view = container.newView()
         view.addContains(Uri.NE, this.class.name, layer.getType())
 
         for (int i; i < layer.size(); ++i) {
@@ -266,7 +270,7 @@ class TCFConverter {
         ConstituentParsingLayer parseLayer = corpus.getConstituentParsingLayer()
         if (!parseLayer) return
 
-        View constituentView = (View) container.newView('constituent-view')
+        View constituentView = (View) container.newView()
         constituentView.addContains(Uri.PHRASE_STRUCTURE, producer, "phrase_structure:fromTCF")
 
         // FIXME Copying tokens to the view is a hack-around until Weblicht supports view ID references.
@@ -312,7 +316,7 @@ class TCFConverter {
                 List<String> childrenIDs
                 if (curNode.node.isTerminal()) {
                     // FIXME Why a class not found for the closure?
-                    childrenIDs = parseLayer.getTokens(curNode.getNode()).collect({"token-view:${it.getID()}"})
+                    childrenIDs = parseLayer.getTokens(curNode.getNode()).collect({"${tokenViewId}:${it.getID()}"})
                     // FIXME See hack-around above.
 //                    childrenIDs = parseLayer.getTokens(curNode.getNode()).collect { it.getID() }
                 } else {
@@ -327,7 +331,7 @@ class TCFConverter {
             }
             // FIXME See above
             // Fixed
-            constituentIds.addAll(parseLayer.getTokens(root).collect({"token-view:${it.getID()}"}))
+            constituentIds.addAll(parseLayer.getTokens(root).collect({"${tokenViewId}:${it.getID()}"}))
 //            constituentIds.addAll(parseLayer.getTokens(root).collect{ it.getID() })
 
             // and then add a "phrase structure" annotation for the current sentence
@@ -341,7 +345,7 @@ class TCFConverter {
         DependencyParsingLayer parseLayer = corpus.getDependencyParsingLayer()
         if (!parseLayer) return
 
-        View dependencyView = (View) container.newView('dependency-view')
+        View dependencyView = (View) container.newView()
         dependencyView.addContains(Uri.DEPENDENCY_STRUCTURE, producer, "dependency_structure:fromTCF")
         // FIXME Copying tokens to the view is a hack-around until Weblicht support views IDs.
         // Weblicht now claims to support view IDs.
@@ -364,11 +368,11 @@ class TCFConverter {
                 Annotation dependency = dependencyView.newAnnotation(dependencyId, Uri.DEPENDENCY)
                 dependency.setLabel(dep.getFunction())
                 for (Token dependent : parseLayer.getDependentTokens(dep)) {
-                    dependency.addFeature(Features.Dependency.DEPENDENT, "token-view:${dependent.getID()}")
+                    dependency.addFeature(Features.Dependency.DEPENDENT, "${tokenViewId}:${dependent.getID()}")
 //                    dependency.addFeature(Features.Dependency.DEPENDENT, dependent.getID())
                 }
                 for (Token governor : parseLayer.getGovernorTokens(dep)) {
-                    dependency.addFeature(Features.Dependency.GOVERNOR, "token-view:${governor.getID()}")
+                    dependency.addFeature(Features.Dependency.GOVERNOR, "${tokenViewId}:${governor.getID()}")
 //                    dependency.addFeature(Features.Dependency.GOVERNOR, governor.getID())
                 }
                 dependencyIds.add(dependencyId)

--- a/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
+++ b/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
@@ -105,8 +105,8 @@ class TCFConverterTests {
         Map<String, String> labels = new HashMap<>()
         for (Annotation annotation : annotations) {
             if (annotation.getAtType() == Uri.PHRASE_STRUCTURE) {
-                // 12 non-terminals and 6 terminals
-                assertEquals(18, parseListString(annotation.getFeature(Features.PhraseStructure.CONSTITUENTS)).length)
+                // 12 constituents and 6 tokens
+                assertEquals(12, parseListString(annotation.getFeature(Features.PhraseStructure.CONSTITUENTS)).length)
             } else {
                 parseListString(annotation.getFeature(Features.Constituent.CHILDREN)).each { String child ->
                     filiations.put(child.replaceAll("^.+:", ""), annotation.getId())

--- a/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
+++ b/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
@@ -148,6 +148,7 @@ class TCFConverterTests {
         assertEquals("S", labels[filiations[filiations["t_5"]]])
         assertEquals("TOP", labels[filiations[filiations[filiations["t_5"]]]])
 
+        println data.asPrettyJson()
     }
 
     String[] parseListString(String string) {

--- a/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
+++ b/src/test/groovy/org/lappsgrid/converter/tcf/TCFConverterTests.groovy
@@ -106,7 +106,9 @@ class TCFConverterTests {
         for (Annotation annotation : annotations) {
             if (annotation.getAtType() == Uri.PHRASE_STRUCTURE) {
                 // 12 non-terminals and 6 terminals
-                assertEquals(18, parseListString(annotation.getFeature(Features.PhraseStructure.CONSTITUENTS)).length)
+//                int expected = 18
+                int expected = 12
+                assertEquals(expected, parseListString(annotation.getFeature(Features.PhraseStructure.CONSTITUENTS)).length)
             } else {
                 parseListString(annotation.getFeature(Features.Constituent.CHILDREN)).each { String child ->
                     filiations.put(child.replaceAll("^.+:", ""), annotation.getId())


### PR DESCRIPTION
- View ID values are generated by the container ensuring they will always be unique.
- The ID assigned to the token view is stored so it can be used in references.

Closes #20 
